### PR TITLE
Make filters functional and display tags on cards

### DIFF
--- a/src/App/index.jsx
+++ b/src/App/index.jsx
@@ -9,8 +9,15 @@ import FilterSelector from '../components/FilterSelector';
 
 
 class App extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      selectedFilters: []
+    }
+  }
+
   setTags = (tags) => {
-    console.log(tags)
+    this.setState({ selectedFilters: tags });
   }
 
   render() {
@@ -25,7 +32,7 @@ class App extends Component {
 
           </Row>
           <Row className="DogTeam" gutter={16}>
-            {getAvailableDogs(allDogs).map(dog => (<DogCard
+            {getAvailableDogs(allDogs, this.state.selectedFilters).map(dog => (<DogCard
               key={dog.name}
               name={dog.name}
               image={dog.image}

--- a/src/App/selectors.js
+++ b/src/App/selectors.js
@@ -1,3 +1,19 @@
-export const getAvailableDogs = (allDogs) => {
-    return allDogs;
+export const getAvailableDogs = (allDogs, selectedFilters) => {
+    if (selectedFilters.length === 0) {
+        return allDogs;
+    } else if (selectedFilters.length === 1) {
+        return allDogs.filter(dog => {
+            return dog.tags.includes(selectedFilters[0])
+        });
+    } else {
+        let filteredDogs = new Set();
+        allDogs.forEach(dog => {
+            selectedFilters.forEach(filter => {
+                if (dog.tags.includes(filter)) {
+                    filteredDogs.add(dog);
+                }
+            })
+        })
+        return [...filteredDogs];
+    }
 }

--- a/src/App/selectors.test.js
+++ b/src/App/selectors.test.js
@@ -2,23 +2,33 @@ import { getAvailableDogs } from './selectors';
 
 const mockListOfDogs = [
     {name: 'doggo 1', tags: ["tag 1"]},
-    {name: 'doggo 2', tags: ["tag 2"]}
+    {name: 'doggo 2', tags: ["tag 2"]},
+    {name: 'doggo 3', tags: ["tag 2", "tag 3"]},
+    {name: 'doggo 4', tags: ["tag 3", "tag 5"]},
+    {name: 'doggo 5', tags: ["tag 1", "tag 2"]}
 ]
 
 describe('getAvailableDogs', () => {
     
     test('it returns all dogs if no filters are selected', () => {
         const selectedFilters = [];
-        expect(getAvailableDogs(mockListOfDogs).length).toEqual(mockListOfDogs.length)
-
+        expect(getAvailableDogs(mockListOfDogs, selectedFilters).length).toEqual(mockListOfDogs.length)
     })
     test('if a filter is selected, only returns dogs with that filter in their tags list', () => {
         const selectedFilters = ['tag 1'];
-
+        expect(getAvailableDogs(mockListOfDogs, selectedFilters).length).toEqual(2);
+        expect(getAvailableDogs(mockListOfDogs, selectedFilters)[0].name).toEqual('doggo 1');
     })
     test('if more than one filter is selected, only returns dogs with either of the filters in their tag list', () => {
         const selectedFilters = ['tag 1', 'tag 2'];
-
-
+        expect(getAvailableDogs(mockListOfDogs, selectedFilters).length).toEqual(4);
+        expect(getAvailableDogs(mockListOfDogs, selectedFilters)).toEqual(
+            [
+                {name: 'doggo 1', tags: ["tag 1"]},
+                {name: 'doggo 2', tags: ["tag 2"]},
+                {name: 'doggo 3', tags: ["tag 2", "tag 3"]},
+                {name: 'doggo 5', tags: ["tag 1", "tag 2"]}
+            ]
+        );
     })
 })

--- a/src/components/DogCard/index.jsx
+++ b/src/components/DogCard/index.jsx
@@ -5,10 +5,11 @@ import { Card, Col } from 'antd';
 const DogPair = ({
     image,
     name,
+    tags
 }) => (
     <Col span={8}>
        <Card
-            title={name}
+            title={`${name} - ${tags.join(', ')}`}
             cover={<img src={`${process.env.PUBLIC_URL}/images/${image}`} alt={`husky named ${name}`}/>}
        >
        </Card>

--- a/src/data/dogs.js
+++ b/src/data/dogs.js
@@ -73,22 +73,22 @@ export default [{
     },
     {
         name: 'Boo',
-        positions: [SHORT_HAIR, TEAM, LEAD, WHEEL, MALE],
+        tags: [SHORT_HAIR, TEAM, LEAD, WHEEL, MALE],
         image: 'boo.png'
     },
     {
         name: 'Jenga',
-        positions: [NEUTERED, ASSERTIVE, SHORT_HAIR, COMMAND_LEAD, TEAM, FEMALE],
+        tags: [NEUTERED, ASSERTIVE, SHORT_HAIR, COMMAND_LEAD, TEAM, FEMALE],
         image: 'jenga.png'
     },
     {
         name: 'Biggie',
-        positions: [YEARLING, TEAM, WHEEL, MALE],
+        tags: [YEARLING, TEAM, WHEEL, MALE],
         image: 'biggie.png'
     },
     {
         name: 'Grinch',
-        positions: [NEUTERED, TEAM, WHEEL, MALE],
+        tags: [NEUTERED, TEAM, WHEEL, MALE],
         image: 'grinch.png'
     },
 ]


### PR DESCRIPTION
Previously, the ability to select filters was present in the UI, but after being selected, the filters did not have an effect on the cards displayed. I implemented a change to the `getAvailableDogs` function to make that UI feature functional. 

As a bonus, the titles of the dog cards now display tags as well, so that the user doesn't have to read through the photo of the hand-written profile to glean what characteristics each dog has.